### PR TITLE
Rename "message" event to "data" event

### DIFF
--- a/examples/cli.php
+++ b/examples/cli.php
@@ -18,7 +18,7 @@ echo '# connecting to redis...' . PHP_EOL;
 $factory->createClient()->then(function (Client $client) use ($loop) {
     echo '# connected! Entering interactive mode, hit CTRL-D to quit' . PHP_EOL;
 
-    $client->on('message', function (ModelInterface $data) {
+    $client->on('data', function (ModelInterface $data) {
         if ($data instanceof ErrorReply) {
             echo '# error reply: ' . $data->getMessage() . PHP_EOL;
         } else {

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,7 +9,7 @@ use Clue\Redis\Protocol\Model\ModelInterface;
 /**
  * Simple interface for executing redis commands
  *
- * @event message(ModelInterface $model, Client $thisClient)
+ * @event data(ModelInterface $messageModel, Client $thisClient)
  * @event close()
  */
 interface Client extends EventEmitterInterface

--- a/src/StreamingClient.php
+++ b/src/StreamingClient.php
@@ -83,7 +83,7 @@ class StreamingClient extends EventEmitter implements Client
 
     public function handleMessage(ModelInterface $message)
     {
-        $this->emit('message', array($message, $this));
+        $this->emit('data', array($message, $this));
 
         if (!$this->requests) {
             throw new UnderflowException('Unexpected reply received, no matching request found');

--- a/tests/StreamingClientTest.php
+++ b/tests/StreamingClientTest.php
@@ -55,7 +55,7 @@ class ClientTest extends TestCase
 
     public function testReceiveMessageEmitsEvent()
     {
-        $this->client->on('message', $this->expectCallableOnce());
+        $this->client->on('data', $this->expectCallableOnce());
 
         $this->parser->expects($this->once())->method('pushIncoming')->with($this->equalTo('message'))->will($this->returnValue(array(new IntegerReply(2))));
         $this->stream->emit('data', array('message'));
@@ -63,8 +63,8 @@ class ClientTest extends TestCase
 
     public function testReceiveThrowMessageEmitsErrorEvent()
     {
-        $this->client->on('message', $this->expectCallableOnce());
-        $this->client->on('message', function() {
+        $this->client->on('data', $this->expectCallableOnce());
+        $this->client->on('data', function() {
             throw new UnderflowException();
         });
 


### PR DESCRIPTION
Rename "message" event to "data" event.

The old event name "message" will be used to pass a Pub/Sub message in a future release. Refs #2.
