### PR TITLE
Returning new promise

### DIFF
--- a/src/StreamingClient.php
+++ b/src/StreamingClient.php
@@ -99,7 +99,7 @@ class StreamingClient extends EventEmitter implements Client
             $subscribed =& $this->subscribed;
             $psubscribed =& $this->psubscribed;
 
-            $promise->then(function ($array) use ($that, &$subscribed, &$psubscribed) {
+            return $promise->then(function ($array) use ($that, &$subscribed, &$psubscribed) {
                 $first = array_shift($array);
 
                 // (p)(un)subscribe messages are to be forwarded


### PR DESCRIPTION
In case of calling on one of this methods ('subscribe', 'unsubscribe', 'psubscribe', 'punsubscribe') the new promise is creating, but never returning and can not be chained. 
Without return in next example error will be muted
```
$client->on('subscribe', function () {
    echo "We subscribed\n";
    throw new \Error("Some error");
});

$client->subscribe('CHANNEL')->otherwise(function ($error) {
    //  Error muted
});
```