### PR TITLE
Fix closing lazy connection from within rejection handler

### DIFF
--- a/examples/subscribe.php
+++ b/examples/subscribe.php
@@ -12,7 +12,8 @@ $channel = isset($argv[1]) ? $argv[1] : 'channel';
 $client = $factory->createLazyClient('localhost');
 $client->subscribe($channel)->then(function () {
     echo 'Now subscribed to channel ' . PHP_EOL;
-}, function (Exception $e) {
+}, function (Exception $e) use ($client) {
+    $client->close();
     echo 'Unable to subscribe: ' . $e->getMessage() . PHP_EOL;
 });
 

--- a/src/LazyClient.php
+++ b/src/LazyClient.php
@@ -166,8 +166,10 @@ class LazyClient extends EventEmitter implements Client
             $this->promise->then(function (Client $client) {
                 $client->close();
             });
-            $this->promise->cancel();
-            $this->promise = null;
+            if ($this->promise !== null) {
+                $this->promise->cancel();
+                $this->promise = null;
+            }
         }
 
         if ($this->idleTimer !== null) {


### PR DESCRIPTION
Builds on top of #87 