### PR TITLE
Update PHPUnit configuration schema for PHPUnit 9.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.travis.yml export-ignore
 /examples/ export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,5 @@ install:
   - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "clue/block-react": "^1.1",
-        "phpunit/phpunit": "^9.0 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     },
     "autoload": {
         "psr-4": { "Clue\\React\\Redis\\": "src/" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="Redis React Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Redis React Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/FactoryStreamingClientTest.php
+++ b/tests/FactoryStreamingClientTest.php
@@ -136,7 +136,7 @@ class FactoryStreamingClientTest extends TestCase
 
     public function testWillResolveWhenAuthCommandReceivesOkResponseIfRedisUriContainsUserInfo()
     {
-        $stream = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(array('write'))->getMock();
+        $stream = $this->createCallableMockWithOriginalConstructorDisabled(array('write'));
         $stream->expects($this->once())->method('write')->with("*2\r\n$4\r\nauth\r\n$5\r\nworld\r\n");
 
         $this->connector->expects($this->once())->method('connect')->willReturn(Promise\resolve($stream));
@@ -149,7 +149,7 @@ class FactoryStreamingClientTest extends TestCase
 
     public function testWillRejectAndCloseAutomaticallyWhenAuthCommandReceivesErrorResponseIfRedisUriContainsUserInfo()
     {
-        $stream = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(array('write', 'close'))->getMock();
+        $stream = $this->createCallableMockWithOriginalConstructorDisabled(array('write', 'close'));
         $stream->expects($this->once())->method('write')->with("*2\r\n$4\r\nauth\r\n$5\r\nworld\r\n");
         $stream->expects($this->once())->method('close');
 
@@ -182,7 +182,7 @@ class FactoryStreamingClientTest extends TestCase
 
     public function testWillResolveWhenSelectCommandReceivesOkResponseIfRedisUriContainsPath()
     {
-        $stream = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(array('write'))->getMock();
+        $stream = $this->createCallableMockWithOriginalConstructorDisabled(array('write'));
         $stream->expects($this->once())->method('write')->with("*2\r\n$6\r\nselect\r\n$3\r\n123\r\n");
 
         $this->connector->expects($this->once())->method('connect')->willReturn(Promise\resolve($stream));
@@ -195,7 +195,7 @@ class FactoryStreamingClientTest extends TestCase
 
     public function testWillRejectAndCloseAutomaticallyWhenSelectCommandReceivesErrorResponseIfRedisUriContainsPath()
     {
-        $stream = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(array('write', 'close'))->getMock();
+        $stream = $this->createCallableMockWithOriginalConstructorDisabled(array('write', 'close'));
         $stream->expects($this->once())->method('write')->with("*2\r\n$6\r\nselect\r\n$3\r\n123\r\n");
         $stream->expects($this->once())->method('close');
 
@@ -336,5 +336,16 @@ class FactoryStreamingClientTest extends TestCase
         ini_set('default_socket_timeout', '42');
         $this->factory->createClient('redis://127.0.0.1:2');
         ini_set('default_socket_timeout', $old);
+    }
+
+    public function createCallableMockWithOriginalConstructorDisabled($array)
+    {
+        if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {
+            // PHPUnit 9+
+            return $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->onlyMethods($array)->getMock();
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 8
+            return $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods($array)->getMock();
+        }
     }
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -149,10 +149,11 @@ class FunctionalTest extends TestCase
         $deferred = new Deferred();
         $consumer->on('message', $this->expectCallableOnce());
         $consumer->on('message', array($deferred, 'resolve'));
-        $consumer->subscribe($channel)->then($this->expectCallableOnce());
-
-        // producer sends a single message
-        $producer->publish($channel, 'hello world')->then($this->expectCallableOnceWith(1));
+        $once = $this->expectCallableOnceWith(1);
+        $consumer->subscribe($channel)->then(function() use ($producer, $channel, $once){
+            // producer sends a single message
+            $producer->publish($channel, 'hello world')->then($once);
+        })->then($this->expectCallableOnce());
 
         // expect "message" event to take no longer than 0.1s
         Block\await($deferred->promise(), $this->loop, 0.1);

--- a/tests/LazyClientTest.php
+++ b/tests/LazyClientTest.php
@@ -156,7 +156,7 @@ class LazyClientTest extends TestCase
 
     public function testPingAfterPreviousUnderlyingClientAlreadyClosedWillCreateNewUnderlyingConnection()
     {
-        $client = $this->getMockBuilder('Clue\React\Redis\StreamingClient')->disableOriginalConstructor()->setMethods(array('__call'))->getMock();
+        $client = $this->createCallableMockWithOriginalConstructorDisabled(array('__call'));
         $client->expects($this->once())->method('__call')->with('ping')->willReturn(\React\Promise\resolve('PONG'));
 
         $this->factory->expects($this->exactly(2))->method('createClient')->willReturnOnConsecutiveCalls(
@@ -183,7 +183,7 @@ class LazyClientTest extends TestCase
     public function testPingAfterPingWillNotStartIdleTimerWhenFirstPingResolves()
     {
         $deferred = new Deferred();
-        $client = $this->getMockBuilder('Clue\React\Redis\StreamingClient')->disableOriginalConstructor()->setMethods(array('__call'))->getMock();
+        $client = $this->createCallableMockWithOriginalConstructorDisabled(array('__call'));
         $client->expects($this->exactly(2))->method('__call')->willReturnOnConsecutiveCalls(
             $deferred->promise(),
             new Promise(function () { })
@@ -201,7 +201,7 @@ class LazyClientTest extends TestCase
     public function testPingAfterPingWillStartAndCancelIdleTimerWhenSecondPingStartsAfterFirstResolves()
     {
         $deferred = new Deferred();
-        $client = $this->getMockBuilder('Clue\React\Redis\StreamingClient')->disableOriginalConstructor()->setMethods(array('__call'))->getMock();
+        $client = $this->createCallableMockWithOriginalConstructorDisabled(array('__call'));
         $client->expects($this->exactly(2))->method('__call')->willReturnOnConsecutiveCalls(
             $deferred->promise(),
             new Promise(function () { })
@@ -220,7 +220,7 @@ class LazyClientTest extends TestCase
 
     public function testPingFollowedByIdleTimerWillCloseUnderlyingConnectionWithoutCloseEvent()
     {
-        $client = $this->getMockBuilder('Clue\React\Redis\StreamingClient')->disableOriginalConstructor()->setMethods(array('__call', 'close'))->getMock();
+        $client = $this->createCallableMockWithOriginalConstructorDisabled(array('__call', 'close'));
         $client->expects($this->once())->method('__call')->willReturn(\React\Promise\resolve());
         $client->expects($this->once())->method('close')->willReturn(\React\Promise\resolve());
 
@@ -298,7 +298,7 @@ class LazyClientTest extends TestCase
     public function testCloseAfterPingWillCancelIdleTimerWhenPingIsAlreadyResolved()
     {
         $deferred = new Deferred();
-        $client = $this->getMockBuilder('Clue\React\Redis\StreamingClient')->disableOriginalConstructor()->setMethods(array('__call', 'close'))->getMock();
+        $client = $this->createCallableMockWithOriginalConstructorDisabled(array('__call', 'close'));
         $client->expects($this->once())->method('__call')->willReturn($deferred->promise());
         $client->expects($this->once())->method('close');
 
@@ -316,7 +316,7 @@ class LazyClientTest extends TestCase
     public function testCloseAfterPingRejectsWillEmitClose()
     {
         $deferred = new Deferred();
-        $client = $this->getMockBuilder('Clue\React\Redis\StreamingClient')->disableOriginalConstructor()->setMethods(array('__call', 'close'))->getMock();
+        $client = $this->createCallableMockWithOriginalConstructorDisabled(array('__call', 'close'));
         $client->expects($this->once())->method('__call')->willReturn($deferred->promise());
         $client->expects($this->once())->method('close')->willReturnCallback(function () use ($client) {
             $client->emit('close');
@@ -358,7 +358,7 @@ class LazyClientTest extends TestCase
 
     public function testEndAfterPingWillCloseClientWhenUnderlyingClientEmitsClose()
     {
-        $client = $this->getMockBuilder('Clue\React\Redis\StreamingClient')->disableOriginalConstructor()->setMethods(array('__call', 'end'))->getMock();
+        $client = $this->createCallableMockWithOriginalConstructorDisabled(array('__call', 'end'));
         $client->expects($this->once())->method('__call')->with('ping')->willReturn(\React\Promise\resolve('PONG'));
         $client->expects($this->once())->method('end');
 
@@ -378,7 +378,7 @@ class LazyClientTest extends TestCase
     {
         $error = new \RuntimeException();
 
-        $client = $this->getMockBuilder('Clue\React\Redis\StreamingClient')->disableOriginalConstructor()->setMethods(array('__call'))->getMock();
+        $client = $this->createCallableMockWithOriginalConstructorDisabled(array('__call'));
         $client->expects($this->once())->method('__call')->willReturn(\React\Promise\resolve());
 
         $deferred = new Deferred();
@@ -393,7 +393,7 @@ class LazyClientTest extends TestCase
 
     public function testEmitsNoCloseEventWhenUnderlyingClientEmitsClose()
     {
-        $client = $this->getMockBuilder('Clue\React\Redis\StreamingClient')->disableOriginalConstructor()->setMethods(array('__call'))->getMock();
+        $client = $this->createCallableMockWithOriginalConstructorDisabled(array('__call'));
         $client->expects($this->once())->method('__call')->willReturn(\React\Promise\resolve());
 
         $deferred = new Deferred();
@@ -409,7 +409,7 @@ class LazyClientTest extends TestCase
     public function testEmitsNoCloseEventButWillCancelIdleTimerWhenUnderlyingConnectionEmitsCloseAfterPingIsAlreadyResolved()
     {
         $deferred = new Deferred();
-        $client = $this->getMockBuilder('Clue\React\Redis\StreamingClient')->disableOriginalConstructor()->setMethods(array('__call'))->getMock();
+        $client = $this->createCallableMockWithOriginalConstructorDisabled(array('__call'));
         $client->expects($this->once())->method('__call')->willReturn($deferred->promise());
 
         $this->factory->expects($this->once())->method('createClient')->willReturn(\React\Promise\resolve($client));
@@ -428,7 +428,7 @@ class LazyClientTest extends TestCase
 
     public function testEmitsMessageEventWhenUnderlyingClientEmitsMessageForPubSubChannel()
     {
-        $client = $this->getMockBuilder('Clue\React\Redis\StreamingClient')->disableOriginalConstructor()->setMethods(array('__call'))->getMock();
+        $client = $this->createCallableMockWithOriginalConstructorDisabled(array('__call'));
         $client->expects($this->once())->method('__call')->willReturn(\React\Promise\resolve());
 
         $deferred = new Deferred();
@@ -443,7 +443,7 @@ class LazyClientTest extends TestCase
 
     public function testEmitsUnsubscribeAndPunsubscribeEventsWhenUnderlyingClientClosesWhileUsingPubSubChannel()
     {
-        $client = $this->getMockBuilder('Clue\React\Redis\StreamingClient')->disableOriginalConstructor()->setMethods(array('__call'))->getMock();
+        $client = $this->createCallableMockWithOriginalConstructorDisabled(array('__call'));
         $client->expects($this->exactly(6))->method('__call')->willReturn(\React\Promise\resolve());
 
         $this->factory->expects($this->once())->method('createClient')->willReturn(\React\Promise\resolve($client));
@@ -474,7 +474,7 @@ class LazyClientTest extends TestCase
     public function testSubscribeWillResolveWhenUnderlyingClientResolvesSubscribeAndNotStartIdleTimerWithIdleDueToSubscription()
     {
         $deferred = new Deferred();
-        $client = $this->getMockBuilder('Clue\React\Redis\StreamingClient')->disableOriginalConstructor()->setMethods(array('__call'))->getMock();
+        $client = $this->createCallableMockWithOriginalConstructorDisabled(array('__call'));
         $client->expects($this->once())->method('__call')->with('subscribe')->willReturn($deferred->promise());
 
         $this->factory->expects($this->once())->method('createClient')->willReturn(\React\Promise\resolve($client));
@@ -492,7 +492,7 @@ class LazyClientTest extends TestCase
     {
         $deferredSubscribe = new Deferred();
         $deferredUnsubscribe = new Deferred();
-        $client = $this->getMockBuilder('Clue\React\Redis\StreamingClient')->disableOriginalConstructor()->setMethods(array('__call'))->getMock();
+        $client = $this->createCallableMockWithOriginalConstructorDisabled(array('__call'));
         $client->expects($this->exactly(2))->method('__call')->willReturnOnConsecutiveCalls($deferredSubscribe->promise(), $deferredUnsubscribe->promise());
 
         $this->factory->expects($this->once())->method('createClient')->willReturn(\React\Promise\resolve($client));
@@ -508,5 +508,16 @@ class LazyClientTest extends TestCase
         $client->emit('unsubscribe', array('foo', 0));
         $deferredUnsubscribe->resolve(array('unsubscribe', 'foo', 0));
         $promise->then($this->expectCallableOnceWith(array('unsubscribe', 'foo', 0)));
+    }
+
+    public function createCallableMockWithOriginalConstructorDisabled($array)
+    {
+        if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {
+            // PHPUnit 9+
+            return $this->getMockBuilder('Clue\React\Redis\StreamingClient')->disableOriginalConstructor()->onlyMethods($array)->getMock();
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 8
+            return $this->getMockBuilder('Clue\React\Redis\StreamingClient')->disableOriginalConstructor()->setMethods($array)->getMock();
+        }
     }
 }


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.
This pull request builds on top of [clue/reactphp-redis#101](https://github.com/clue/reactphp-redis/pull/101).

It's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0beta1-cli php vendor/bin/phpunit
PHPUnit 9.3.8 by Sebastian Bergmann and contributors.

.........................................SSSSSSSSSSSSSS........  63 / 104 ( 60%)
.........................................                       104 / 104 (100%)

Time: 00:00.045, Memory: 8.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 104, Assertions: 227, Skipped: 14.
```