### PR TITLE
Fix dangling timer when lazy connection closes with pending commands

### DIFF
--- a/src/LazyClient.php
+++ b/src/LazyClient.php
@@ -201,7 +201,7 @@ class LazyClient extends EventEmitter implements Client
     {
         --$this->pending;
 
-        if ($this->pending < 1 && $this->idlePeriod >= 0 && !$this->subscribed && !$this->psubscribed) {
+        if ($this->pending < 1 && $this->idlePeriod >= 0 && !$this->subscribed && !$this->psubscribed && $this->promise !== null) {
             $idleTimer =& $this->idleTimer;
             $promise =& $this->promise;
             $idleTimer = $this->loop->addTimer($this->idlePeriod, function () use (&$idleTimer, &$promise) {


### PR DESCRIPTION
This is a somewhat hidden and rare race condition. The faulty idle timer
would be started when the underlying Redis connection closes while the
lazy connection still has pending commands, such as a blocking BLPOP
operation. The timer would trigger some timer after the connection has
been closed and would try to close the connection again, thus
referencing undefined variables and causing a hard error in this case.

The idle timer should not be started when the connection is already
closed.