### PR TITLE
Fix phpDoc magic method hinting in Client class

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -8,16 +8,15 @@ use React\Promise\PromiseInterface;
 /**
  * Simple interface for executing redis commands
  *
- * @event error(Exception $error)
- * @event close()
+ * @method error(Exception $error)
  *
- * @event message($channel, $message)
- * @event subscribe($channel, $numberOfChannels)
- * @event unsubscribe($channel, $numberOfChannels)
+ * @method publish($channel, $message)
+ * @method subscribe($channel)
+ * @method unsubscribe($channel)
  *
- * @event pmessage($pattern, $channel, $message)
- * @event psubscribe($channel, $numberOfChannels)
- * @event punsubscribe($channel, $numberOfChannels)
+ * @method pmessage($pattern, $channel, $message)
+ * @method psubscribe($channel)
+ * @method punsubscribe($channel)
  */
 interface Client extends EventEmitterInterface
 {


### PR DESCRIPTION
Hi, thanks for this great library!
There were the following issues with the docBlock at the top of the `Client` class which I have fixed in this PR:
- `@event` does not exist, `@method` has to be used (also see the [phpDoc tag reference](https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/index.html#tag-reference)).
- The `message` method does not exist, it is called `publish` (all examples use `publish`, see also related issue #106).
- The error method is defined in this class with its own phpDoc-block and does not have to be hinted at the top.
- The `numberOfChannels`-Parameter does not exist and is not used anywhere

Since my code analysis tool needs correct method hints to be happy, it would be nice if you could merge this.
Thanks!