### PR TITLE
Simplify usage by supporting new Socket API

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,12 @@ here in order to use the [default loop](https://github.com/reactphp/event-loop#l
 This value SHOULD NOT be given unless you're sure you want to explicitly use a
 given event loop instance.
 
-If you need custom DNS, proxy or TLS settings, you can explicitly pass a
-custom instance of the [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
+If you need custom connector settings (DNS resolution, TLS parameters, timeouts,
+proxy servers etc.), you can explicitly pass a custom instance of the
+[`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
 
 ```php
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'dns' => '127.0.0.1',
     'tcp' => array(
         'bindto' => '192.168.10.1:0'

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "react/event-loop": "^1.2",
         "react/promise": "^2.0 || ^1.1",
         "react/promise-timer": "^1.5",
-        "react/socket": "^1.8"
+        "react/socket": "^1.9"
     },
     "require-dev": {
         "clue/block-react": "^1.1",

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -31,7 +31,7 @@ class Factory
     public function __construct(LoopInterface $loop = null, ConnectorInterface $connector = null, ProtocolFactory $protocol = null)
     {
         $this->loop = $loop ?: Loop::get();
-        $this->connector = $connector ?: new Connector($this->loop);
+        $this->connector = $connector ?: new Connector(array(), $this->loop);
         $this->protocol = $protocol ?: new ProtocolFactory();
     }
 


### PR DESCRIPTION
This changeset simplifies usage by supporting the new Socket API without nullable loop arguments.

Note that this doesn't affect the API of this package at all, but does use the improved API of the referenced Socket component. Existing code continues to work as is.

Together with #114, this means we can now fully rely on the [default loop](https://github.com/reactphp/event-loop#loop) and no longer need to skip any arguments with null values.

Builds on top of reactphp/socket#264