### PR TITLE
Improve error reporting, include Redis URI and socket error codes in all connection errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ $factory = new Clue\React\Redis\Factory(null, $connector);
 
 #### createClient()
 
-The `createClient(string $redisUri): PromiseInterface<Client,Exception>` method can be used to
+The `createClient(string $uri): PromiseInterface<Client,Exception>` method can be used to
 create a new [`Client`](#client).
 
 It helps with establishing a plain TCP/IP or secure TLS connection to Redis
@@ -215,7 +215,7 @@ $factory->createClient('localhost?timeout=0.5');
 
 #### createLazyClient()
 
-The `createLazyClient(string $redisUri): Client` method can be used to
+The `createLazyClient(string $uri): Client` method can be used to
 create a new [`Client`](#client).
 
 It helps with establishing a plain TCP/IP or secure TLS connection to Redis

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ local Redis server and send some requests:
 
 ```php
 $factory = new Clue\React\Redis\Factory();
+$client = $factory->createLazyClient('localhost:6379');
 
-$client = $factory->createLazyClient('localhost');
 $client->set('greeting', 'Hello world');
 $client->append('greeting', '!');
 
@@ -125,7 +125,7 @@ It helps with establishing a plain TCP/IP or secure TLS connection to Redis
 and optionally authenticating (AUTH) and selecting the right database (SELECT).
 
 ```php
-$factory->createClient('redis://localhost:6379')->then(
+$factory->createClient('localhost:6379')->then(
     function (Client $client) {
         // client connected (and authenticated)
     },
@@ -146,7 +146,7 @@ reject its value with an Exception and will cancel the underlying TCP/IP
 connection attempt and/or Redis authentication.
 
 ```php
-$promise = $factory->createClient($redisUri);
+$promise = $factory->createClient($uri);
 
 Loop::addTimer(3.0, function () use ($promise) {
     $promise->cancel();
@@ -222,7 +222,7 @@ It helps with establishing a plain TCP/IP or secure TLS connection to Redis
 and optionally authenticating (AUTH) and selecting the right database (SELECT).
 
 ```php
-$client = $factory->createLazyClient('redis://localhost:6379');
+$client = $factory->createLazyClient('localhost:6379');
 
 $client->incr('hello');
 $client->end();

--- a/examples/cli.php
+++ b/examples/cli.php
@@ -1,5 +1,8 @@
 <?php
 
+// $ php examples/cli.php
+// $ REDIS_URI=localhost:6379 php examples/cli.php
+
 use Clue\React\Redis\Client;
 use Clue\React\Redis\Factory;
 use React\EventLoop\Loop;
@@ -11,7 +14,7 @@ $factory = new Factory();
 
 echo '# connecting to redis...' . PHP_EOL;
 
-$factory->createClient('localhost')->then(function (Client $client) {
+$factory->createClient(getenv('REDIS_URI') ?: 'localhost:6379')->then(function (Client $client) {
     echo '# connected! Entering interactive mode, hit CTRL-D to quit' . PHP_EOL;
 
     Loop::addReadStream(STDIN, function () use ($client) {
@@ -38,7 +41,7 @@ $factory->createClient('localhost')->then(function (Client $client) {
 
         $promise->then(function ($data) {
             echo '# reply: ' . json_encode($data) . PHP_EOL;
-        }, function ($e) {
+        }, function (Exception $e) {
             echo '# error reply: ' . $e->getMessage() . PHP_EOL;
         });
     });
@@ -48,10 +51,7 @@ $factory->createClient('localhost')->then(function (Client $client) {
 
         Loop::removeReadStream(STDIN);
     });
-}, function (Exception $error) {
-    echo 'CONNECTION ERROR: ' . $error->getMessage() . PHP_EOL;
-    if ($error->getPrevious()) {
-        echo $error->getPrevious()->getMessage() . PHP_EOL;
-    }
+}, function (Exception $e) {
+    echo 'Error: ' . $e->getMessage() . PHP_EOL;
     exit(1);
 });

--- a/examples/incr.php
+++ b/examples/incr.php
@@ -1,22 +1,22 @@
 <?php
 
+// $ php examples/incr.php
+// $ REDIS_URI=localhost:6379 php examples/incr.php
+
 use Clue\React\Redis\Factory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $factory = new Factory();
+$client = $factory->createLazyClient(getenv('REDIS_URI') ?: 'localhost:6379');
 
-$client = $factory->createLazyClient('localhost');
 $client->incr('test');
 
 $client->get('test')->then(function ($result) {
     var_dump($result);
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
-    if ($e->getPrevious()) {
-        echo $e->getPrevious()->getMessage() . PHP_EOL;
-    }
     exit(1);
 });
 
-$client->end();
+//$client->end();

--- a/examples/publish.php
+++ b/examples/publish.php
@@ -1,22 +1,22 @@
 <?php
 
+// $ php examples/publish.php
+// $ REDIS_URI=localhost:6379 php examples/publish.php channel message
+
 use Clue\React\Redis\Factory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $factory = new Factory();
+$client = $factory->createLazyClient(getenv('REDIS_URI') ?: 'localhost:6379');
 
 $channel = isset($argv[1]) ? $argv[1] : 'channel';
 $message = isset($argv[2]) ? $argv[2] : 'message';
 
-$client = $factory->createLazyClient('localhost');
 $client->publish($channel, $message)->then(function ($received) {
     echo 'Successfully published. Received by ' . $received . PHP_EOL;
 }, function (Exception $e) {
     echo 'Unable to publish: ' . $e->getMessage() . PHP_EOL;
-    if ($e->getPrevious()) {
-        echo $e->getPrevious()->getMessage() . PHP_EOL;
-    }
     exit(1);
 });
 

--- a/examples/subscribe.php
+++ b/examples/subscribe.php
@@ -1,15 +1,18 @@
 <?php
 
+// $ php examples/subscribe.php
+// $ REDIS_URI=localhost:6379 php examples/subscribe.php channel
+
 use Clue\React\Redis\Factory;
 use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $factory = new Factory();
+$client = $factory->createLazyClient(getenv('REDIS_URI') ?: 'localhost:6379');
 
 $channel = isset($argv[1]) ? $argv[1] : 'channel';
 
-$client = $factory->createLazyClient('localhost');
 $client->subscribe($channel)->then(function () {
     echo 'Now subscribed to channel ' . PHP_EOL;
 }, function (Exception $e) use ($client) {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -111,9 +111,16 @@ class Factory
                     function (\Exception $e) use ($client, $uri) {
                         $client->close();
 
+                        $const = '';
+                        $errno = $e->getCode();
+                        if ($errno === 0) {
+                            $const = ' (EACCES)';
+                            $errno = $e->getCode() ?: (defined('SOCKET_EACCES') ? SOCKET_EACCES : 13);
+                        }
+
                         throw new \RuntimeException(
-                            'Connection to ' . $uri . ' failed during AUTH command: ' . $e->getMessage() . ' (EACCES)',
-                            defined('SOCKET_EACCES') ? SOCKET_EACCES : 13,
+                            'Connection to ' . $uri . ' failed during AUTH command: ' . $e->getMessage() . $const,
+                            $errno,
                             $e
                         );
                     }
@@ -132,9 +139,19 @@ class Factory
                     function (\Exception $e) use ($client, $uri) {
                         $client->close();
 
+                        $const = '';
+                        $errno = $e->getCode();
+                        if ($errno === 0 && strpos($e->getMessage(), 'NOAUTH ') === 0) {
+                            $const = ' (EACCES)';
+                            $errno = defined('SOCKET_EACCES') ? SOCKET_EACCES : 13;
+                        } elseif ($errno === 0) {
+                            $const = ' (ENOENT)';
+                            $errno = defined('SOCKET_ENOENT') ? SOCKET_ENOENT : 2;
+                        }
+
                         throw new \RuntimeException(
-                            'Connection to ' . $uri . ' failed during SELECT command: ' . $e->getMessage() . ' (ENOENT)',
-                            defined('SOCKET_ENOENT') ? SOCKET_ENOENT : 2,
+                            'Connection to ' . $uri . ' failed during SELECT command: ' . $e->getMessage() . $const,
+                            $errno,
                             $e
                         );
                     }

--- a/src/LazyClient.php
+++ b/src/LazyClient.php
@@ -115,7 +115,10 @@ class LazyClient extends EventEmitter implements Client
     public function __call($name, $args)
     {
         if ($this->closed) {
-            return \React\Promise\reject(new \RuntimeException('Connection closed'));
+            return \React\Promise\reject(new \RuntimeException(
+                'Connection closed (ENOTCONN)',
+                defined('SOCKET_ENOTCONN') ? SOCKET_ENOTCONN : 107
+            ));
         }
 
         $that = $this;

--- a/src/StreamingClient.php
+++ b/src/StreamingClient.php
@@ -2,18 +2,15 @@
 
 namespace Clue\React\Redis;
 
-use Evenement\EventEmitter;
-use Clue\Redis\Protocol\Parser\ParserInterface;
-use Clue\Redis\Protocol\Parser\ParserException;
-use Clue\Redis\Protocol\Serializer\SerializerInterface;
 use Clue\Redis\Protocol\Factory as ProtocolFactory;
-use UnderflowException;
-use RuntimeException;
-use InvalidArgumentException;
-use React\Promise\Deferred;
 use Clue\Redis\Protocol\Model\ErrorReply;
 use Clue\Redis\Protocol\Model\ModelInterface;
 use Clue\Redis\Protocol\Model\MultiBulkReply;
+use Clue\Redis\Protocol\Parser\ParserException;
+use Clue\Redis\Protocol\Parser\ParserInterface;
+use Clue\Redis\Protocol\Serializer\SerializerInterface;
+use Evenement\EventEmitter;
+use React\Promise\Deferred;
 use React\Stream\DuplexStreamInterface;
 
 /**
@@ -47,9 +44,12 @@ class StreamingClient extends EventEmitter implements Client
         $stream->on('data', function($chunk) use ($parser, $that) {
             try {
                 $models = $parser->pushIncoming($chunk);
-            }
-            catch (ParserException $error) {
-                $that->emit('error', array($error));
+            } catch (ParserException $error) {
+                $that->emit('error', array(new \UnexpectedValueException(
+                    'Invalid data received: ' . $error->getMessage() . ' (EBADMSG)',
+                    defined('SOCKET_EBADMSG') ? SOCKET_EBADMSG : 77,
+                    $error
+                )));
                 $that->close();
                 return;
             }
@@ -57,8 +57,7 @@ class StreamingClient extends EventEmitter implements Client
             foreach ($models as $data) {
                 try {
                     $that->handleMessage($data);
-                }
-                catch (UnderflowException $error) {
+                } catch (\UnderflowException $error) {
                     $that->emit('error', array($error));
                     $that->close();
                     return;
@@ -84,11 +83,20 @@ class StreamingClient extends EventEmitter implements Client
         static $pubsubs = array('subscribe', 'unsubscribe', 'psubscribe', 'punsubscribe');
 
         if ($this->ending) {
-            $request->reject(new RuntimeException('Connection closed'));
+            $request->reject(new \RuntimeException(
+                'Connection ' . ($this->closed ? 'closed' : 'closing'). ' (ENOTCONN)',
+                defined('SOCKET_ENOTCONN') ? SOCKET_ENOTCONN : 107
+            ));
         } elseif (count($args) !== 1 && in_array($name, $pubsubs)) {
-            $request->reject(new InvalidArgumentException('PubSub commands limited to single argument'));
+            $request->reject(new \InvalidArgumentException(
+                'PubSub commands limited to single argument (EINVAL)',
+                defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22
+            ));
         } elseif ($name === 'monitor') {
-            $request->reject(new \BadMethodCallException('MONITOR command explicitly not supported'));
+            $request->reject(new \BadMethodCallException(
+                'MONITOR command explicitly not supported (ENOTSUP)',
+                defined('SOCKET_ENOTSUP') ? SOCKET_ENOTSUP : (defined('SOCKET_EOPNOTSUPP') ? SOCKET_EOPNOTSUPP : 95)
+            ));
         } else {
             $this->stream->write($this->serializer->getRequestMessage($name, $args));
             $this->requests []= $request;
@@ -131,7 +139,10 @@ class StreamingClient extends EventEmitter implements Client
         }
 
         if (!$this->requests) {
-            throw new UnderflowException('Unexpected reply received, no matching request found');
+            throw new \UnderflowException(
+                'Unexpected reply received, no matching request found (ENOMSG)',
+                defined('SOCKET_ENOMSG') ? SOCKET_ENOMSG : 42
+            );
         }
 
         $request = array_shift($this->requests);
@@ -173,8 +184,11 @@ class StreamingClient extends EventEmitter implements Client
         // reject all remaining requests in the queue
         while($this->requests) {
             $request = array_shift($this->requests);
-            /* @var $request Request */
-            $request->reject(new RuntimeException('Connection closing'));
+            /* @var $request Deferred */
+            $request->reject(new \RuntimeException(
+                'Connection closing (ENOTCONN)',
+                defined('SOCKET_ENOTCONN') ? SOCKET_ENOTCONN : 107
+            ));
         }
     }
 }

--- a/tests/FactoryStreamingClientTest.php
+++ b/tests/FactoryStreamingClientTest.php
@@ -136,6 +136,15 @@ class FactoryStreamingClientTest extends TestCase
         $this->factory->createClient('redis+unix:///tmp/redis.sock?password=world');
     }
 
+    public function testWillNotWriteAnyCommandIfRedisUnixUriContainsNoPasswordOrDb()
+    {
+        $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $stream->expects($this->never())->method('write');
+
+        $this->connector->expects($this->once())->method('connect')->with('unix:///tmp/redis.sock')->willReturn(Promise\resolve($stream));
+        $this->factory->createClient('redis+unix:///tmp/redis.sock');
+    }
+
     public function testWillWriteAuthCommandIfRedisUnixUriContainsUserInfo()
     {
         $stream = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();

--- a/tests/FactoryStreamingClientTest.php
+++ b/tests/FactoryStreamingClientTest.php
@@ -200,7 +200,10 @@ class FactoryStreamingClientTest extends TestCase
             $this->logicalAnd(
                 $this->isInstanceOf('RuntimeException'),
                 $this->callback(function (\RuntimeException $e) {
-                    return $e->getMessage() === 'Connection to redis://:***@localhost failed during AUTH command: ERR invalid password';
+                    return $e->getMessage() === 'Connection to redis://:***@localhost failed during AUTH command: ERR invalid password (EACCES)';
+                }),
+                $this->callback(function (\RuntimeException $e) {
+                    return $e->getCode() === (defined('SOCKET_EACCES') ? SOCKET_EACCES : 13);
                 }),
                 $this->callback(function (\RuntimeException $e) {
                     return $e->getPrevious()->getMessage() === 'ERR invalid password';
@@ -264,7 +267,10 @@ class FactoryStreamingClientTest extends TestCase
             $this->logicalAnd(
                 $this->isInstanceOf('RuntimeException'),
                 $this->callback(function (\RuntimeException $e) {
-                    return $e->getMessage() === 'Connection to redis://localhost/123 failed during SELECT command: ERR DB index is out of range';
+                    return $e->getMessage() === 'Connection to redis://localhost/123 failed during SELECT command: ERR DB index is out of range (ENOENT)';
+                }),
+                $this->callback(function (\RuntimeException $e) {
+                    return $e->getCode() === (defined('SOCKET_ENOENT') ? SOCKET_ENOENT : 2);
                 }),
                 $this->callback(function (\RuntimeException $e) {
                     return $e->getPrevious()->getMessage() === 'ERR DB index is out of range';
@@ -285,6 +291,9 @@ class FactoryStreamingClientTest extends TestCase
                     return $e->getMessage() === 'Connection to redis://127.0.0.1:2 failed: Foo';
                 }),
                 $this->callback(function (\RuntimeException $e) {
+                    return $e->getCode() === 42;
+                }),
+                $this->callback(function (\RuntimeException $e) {
                     return $e->getPrevious()->getMessage() === 'Foo';
                 })
             )
@@ -299,7 +308,10 @@ class FactoryStreamingClientTest extends TestCase
             $this->logicalAnd(
                 $this->isInstanceOf('InvalidArgumentException'),
                 $this->callback(function (\InvalidArgumentException $e) {
-                    return $e->getMessage() === 'Invalid Redis URI given';
+                    return $e->getMessage() === 'Invalid Redis URI given (EINVAL)';
+                }),
+                $this->callback(function (\InvalidArgumentException $e) {
+                    return $e->getCode() === (defined('SOCKET_EINVAL') ? SOCKET_EINVAL : 22);
                 })
             )
         ));
@@ -399,7 +411,10 @@ class FactoryStreamingClientTest extends TestCase
             $this->logicalAnd(
                 $this->isInstanceOf('RuntimeException'),
                 $this->callback(function (\RuntimeException $e) use ($safe) {
-                    return $e->getMessage() === 'Connection to ' . $safe . ' cancelled';
+                    return $e->getMessage() === 'Connection to ' . $safe . ' cancelled (ECONNABORTED)';
+                }),
+                $this->callback(function (\RuntimeException $e) {
+                    return $e->getCode() === (defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103);
                 })
             )
         ));
@@ -420,7 +435,10 @@ class FactoryStreamingClientTest extends TestCase
             $this->logicalAnd(
                 $this->isInstanceOf('RuntimeException'),
                 $this->callback(function (\RuntimeException $e) {
-                    return $e->getMessage() === 'Connection to redis://127.0.0.1:2/123 cancelled';
+                    return $e->getMessage() === 'Connection to redis://127.0.0.1:2/123 cancelled (ECONNABORTED)';
+                }),
+                $this->callback(function (\RuntimeException $e) {
+                    return $e->getCode() === (defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103);
                 })
             )
         ));
@@ -446,7 +464,10 @@ class FactoryStreamingClientTest extends TestCase
             $this->logicalAnd(
                 $this->isInstanceOf('RuntimeException'),
                 $this->callback(function (\Exception $e) {
-                    return $e->getMessage() === 'Connection to redis://127.0.0.1:2?timeout=0 timed out after 0 seconds';
+                    return $e->getMessage() === 'Connection to redis://127.0.0.1:2?timeout=0 timed out after 0 seconds (ETIMEDOUT)';
+                }),
+                $this->callback(function (\Exception $e) {
+                    return $e->getCode() === (defined('SOCKET_ETIMEDOUT') ? SOCKET_ETIMEDOUT : 110);
                 })
             )
         ));

--- a/tests/LazyClientTest.php
+++ b/tests/LazyClientTest.php
@@ -185,7 +185,17 @@ class LazyClientTest extends TestCase
         $this->client->close();
         $promise = $this->client->ping();
 
-        $promise->then(null, $this->expectCallableOnce());
+        $promise->then(null, $this->expectCallableOnceWith(
+            $this->logicalAnd(
+                $this->isInstanceOf('RuntimeException'),
+                $this->callback(function (\RuntimeException $e) {
+                    return $e->getMessage() === 'Connection closed (ENOTCONN)';
+                }),
+                $this->callback(function (\RuntimeException $e) {
+                    return $e->getCode() === (defined('SOCKET_ENOTCONN') ? SOCKET_ENOTCONN : 107);
+                })
+            )
+        ));
     }
 
     public function testPingAfterPingWillNotStartIdleTimerWhenFirstPingResolves()


### PR DESCRIPTION
This changeset improves error reporting to include the Redis URI and socket error codes in all connection errors:

```diff
- Error: Connection to Redis server failed because underlying transport connection failed
+ Error: Connection to redis://localhost failed: Connection to localhost:6379 failed: Last error for IPv4: Connection to tcp://127.0.0.1:6379?hostname=localhost failed: Connection refused. Previous error for IPv6: Connection to tcp://[::1]:6379?hostname=localhost failed: Connection refused
```

Builds on top of #89, https://github.com/clue/reactphp-http-proxy/pull/17 and others