### PR TITLE
Support PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.1
           - 8.0
           - 7.4
           - 7.3

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/event-loop": "^1.2",
         "react/promise": "^2.0 || ^1.1",
-        "react/promise-timer": "^1.5",
+        "react/promise-timer": "^1.8",
         "react/socket": "^1.9"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,8 +4,9 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
+         cacheResult="false"
          colors="true"
-         cacheResult="false">
+         convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="Redis React Test Suite">
             <directory>./tests/</directory>

--- a/src/LazyClient.php
+++ b/src/LazyClient.php
@@ -31,7 +31,7 @@ class LazyClient extends EventEmitter implements Client
     public function __construct($target, Factory $factory, LoopInterface $loop)
     {
         $args = array();
-        \parse_str(\parse_url($target, \PHP_URL_QUERY), $args);
+        \parse_str((string) \parse_url($target, \PHP_URL_QUERY), $args);
         if (isset($args['idle'])) {
             $this->idlePeriod = (float)$args['idle'];
         }


### PR DESCRIPTION
This changeset adds support for PHP 8.1.

~~I'm marking this as WIP because it currently reports a deprecation notice that needs to be addressed upstream first (https://github.com/reactphp/promise-timer/pull/50). I'll update this PR once this version is released.~~

Builds on top of #111
Refs https://github.com/friends-of-reactphp/mysql/pull/150