### PR TITLE
Drop HHVM support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,16 +34,3 @@ jobs:
         if: ${{ matrix.php >= 7.3 }}
       - run: REDIS_URI=localhost:6379 vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
         if: ${{ matrix.php < 7.3 }}
-
-  PHPUnit-hhvm:
-    name: PHPUnit (HHVM)
-    runs-on: ubuntu-18.04
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v2
-      - uses: azjezz/setup-hhvm@v1
-        with:
-          version: lts-3.30
-      - run: hhvm $(which composer) install
-      - run: docker run --net=host -d redis
-      - run: REDIS_URI=localhost:6379 hhvm vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -616,8 +616,7 @@ $ composer require clue/redis-react:^2.5
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
-HHVM.
+extensions and supports running on legacy PHP 5.3 through current PHP 8+.
 It's *highly recommended to use the latest supported PHP version* for this project.
 
 ## Tests


### PR DESCRIPTION
Due to HHVM's decrease in use, there's no more need to support it.

For reference take a look at the similar conversation in https://github.com/clue/confgen/pull/37 or https://github.com/clue/confgen/pull/39.