### PR TITLE
Add type definitions for all APIs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ $redis = $factory->createLazyClient('localhost:6379');
 $redis->set('greeting', 'Hello world');
 $redis->append('greeting', '!');
 
-$redis->get('greeting')->then(function ($greeting) {
+$redis->get('greeting')->then(function (string $greeting) {
     // Hello world!
     echo $greeting . PHP_EOL;
 });
 
-$redis->incr('invocation')->then(function ($n) {
+$redis->incr('invocation')->then(function (int $n) {
     echo 'This is invocation #' . $n . PHP_EOL;
 });
 
@@ -184,7 +184,7 @@ subscribe to a channel and then receive incoming PubSub `message` events:
 $channel = 'user';
 $redis->subscribe($channel);
 
-$redis->on('message', function ($channel, $payload) {
+$redis->on('message', function (string $channel, string $payload) {
     // pubsub message received on given $channel
     var_dump($channel, json_decode($payload));
 });
@@ -208,7 +208,7 @@ all incoming PubSub messages with the `pmessage` event:
 $pattern = 'user.*';
 $redis->psubscribe($pattern);
 
-$redis->on('pmessage', function ($pattern, $channel, $payload) {
+$redis->on('pmessage', function (string $pattern, string $channel, string $payload) {
     // pubsub message received matching given $pattern
     var_dump($channel, json_decode($payload));
 });
@@ -248,16 +248,16 @@ Additionally, can listen for the following PubSub events to get notifications
 about subscribed/unsubscribed channels and patterns:
 
 ```php
-$redis->on('subscribe', function ($channel, $total) {
+$redis->on('subscribe', function (string $channel, int $total) {
     // subscribed to given $channel
 });
-$redis->on('psubscribe', function ($pattern, $total) {
+$redis->on('psubscribe', function (string $pattern, int $total) {
     // subscribed to matching given $pattern
 });
-$redis->on('unsubscribe', function ($channel, $total) {
+$redis->on('unsubscribe', function (string $channel, int $total) {
     // unsubscribed from given $channel
 });
-$redis->on('punsubscribe', function ($pattern, $total) {
+$redis->on('punsubscribe', function (string $pattern, int $total) {
     // unsubscribed from matching given $pattern
 });
 ```

--- a/examples/incr.php
+++ b/examples/incr.php
@@ -10,7 +10,7 @@ $redis = $factory->createLazyClient(getenv('REDIS_URI') ?: 'localhost:6379');
 
 $redis->incr('test');
 
-$redis->get('test')->then(function ($result) {
+$redis->get('test')->then(function (string $result) {
     var_dump($result);
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;

--- a/examples/publish.php
+++ b/examples/publish.php
@@ -11,7 +11,7 @@ $redis = $factory->createLazyClient(getenv('REDIS_URI') ?: 'localhost:6379');
 $channel = $argv[1] ?? 'channel';
 $message = $argv[2] ?? 'message';
 
-$redis->publish($channel, $message)->then(function ($received) {
+$redis->publish($channel, $message)->then(function (int $received) {
     echo 'Successfully published. Received by ' . $received . PHP_EOL;
 }, function (Exception $e) {
     echo 'Unable to publish: ' . $e->getMessage() . PHP_EOL;

--- a/examples/subscribe.php
+++ b/examples/subscribe.php
@@ -19,15 +19,15 @@ $redis->subscribe($channel)->then(function () {
     echo 'Unable to subscribe: ' . $e->getMessage() . PHP_EOL;
 });
 
-$redis->on('message', function ($channel, $message) {
+$redis->on('message', function (string $channel, string $message) {
     echo 'Message on ' . $channel . ': ' . $message . PHP_EOL;
 });
 
 // automatically re-subscribe to channel on connection issues
-$redis->on('unsubscribe', function ($channel) use ($redis) {
+$redis->on('unsubscribe', function (string $channel) use ($redis) {
     echo 'Unsubscribed from ' . $channel . PHP_EOL;
 
-    Loop::addPeriodicTimer(2.0, function ($timer) use ($redis, $channel){
+    Loop::addPeriodicTimer(2.0, function (React\EventLoop\TimerInterface $timer) use ($redis, $channel){
         $redis->subscribe($channel)->then(function () use ($timer) {
             echo 'Now subscribed again' . PHP_EOL;
             Loop::cancelTimer($timer);

--- a/src/Client.php
+++ b/src/Client.php
@@ -31,7 +31,7 @@ interface Client extends EventEmitterInterface
      * @param string[] $args
      * @return PromiseInterface Promise<mixed,Exception>
      */
-    public function __call($name, $args);
+    public function __call(string $name, array $args): PromiseInterface;
 
     /**
      * end connection once all pending requests have been replied to
@@ -40,7 +40,7 @@ interface Client extends EventEmitterInterface
      * @uses self::close() once all replies have been received
      * @see self::close() for closing the connection immediately
      */
-    public function end();
+    public function end(): void;
 
     /**
      * close connection immediately
@@ -50,5 +50,5 @@ interface Client extends EventEmitterInterface
      * @return void
      * @see self::end() for closing the connection once the client is idle
      */
-    public function close();
+    public function close(): void;
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -6,6 +6,7 @@ use Clue\Redis\Protocol\Factory as ProtocolFactory;
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
+use React\Promise\PromiseInterface;
 use React\Promise\Timer\TimeoutException;
 use React\Socket\ConnectionInterface;
 use React\Socket\Connector;
@@ -40,10 +41,10 @@ class Factory
      * Create Redis client connected to address of given redis instance
      *
      * @param string $uri Redis server URI to connect to
-     * @return \React\Promise\PromiseInterface<Client,\Exception> Promise that will
+     * @return PromiseInterface<Client,\Exception> Promise that will
      *     be fulfilled with `Client` on success or rejects with `\Exception` on error.
      */
-    public function createClient($uri)
+    public function createClient(string $uri): PromiseInterface
     {
         // support `redis+unix://` scheme for Unix domain socket (UDS) paths
         if (preg_match('/^(redis\+unix:\/\/(?:[^:]*:[^@]*@)?)(.+?)?$/', $uri, $match)) {
@@ -184,7 +185,7 @@ class Factory
      * @param string $target
      * @return Client
      */
-    public function createLazyClient($target)
+    public function createLazyClient($target): Client
     {
         return new LazyClient($target, $this, $this->loop);
     }

--- a/tests/FactoryLazyClientTest.php
+++ b/tests/FactoryLazyClientTest.php
@@ -4,6 +4,7 @@ namespace Clue\Tests\React\Redis;
 
 use Clue\React\Redis\Client;
 use Clue\React\Redis\Factory;
+use PHPUnit\Framework\MockObject\MockObject;
 use React\EventLoop\LoopInterface;
 use React\Socket\ConnectionInterface;
 use React\Socket\ConnectorInterface;
@@ -12,14 +13,16 @@ use function React\Promise\resolve;
 
 class FactoryLazyClientTest extends TestCase
 {
+    /** @var MockObject */
     private $loop;
+
+    /** @var MockObject */
     private $connector;
+
+    /** @var Factory */
     private $factory;
 
-    /**
-     * @before
-     */
-    public function setUpFactory()
+    public function setUp(): void
     {
         $this->loop = $this->createMock(LoopInterface::class);
         $this->connector = $this->createMock(ConnectorInterface::class);

--- a/tests/FactoryStreamingClientTest.php
+++ b/tests/FactoryStreamingClientTest.php
@@ -4,6 +4,7 @@ namespace Clue\Tests\React\Redis;
 
 use Clue\React\Redis\Client;
 use Clue\React\Redis\Factory;
+use PHPUnit\Framework\MockObject\MockObject;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
 use React\Socket\ConnectionInterface;
@@ -13,14 +14,16 @@ use function React\Promise\resolve;
 
 class FactoryStreamingClientTest extends TestCase
 {
+    /** @var MockObject */
     private $loop;
+
+    /** @var MockObject */
     private $connector;
+
+    /** @var Factory */
     private $factory;
 
-    /**
-     * @before
-     */
-    public function setUpFactory()
+    public function setUp(): void
     {
         $this->loop = $this->createMock(LoopInterface::class);
         $this->connector = $this->createMock(ConnectorInterface::class);

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -13,17 +13,19 @@ use function Clue\React\Block\await;
 
 class FunctionalTest extends TestCase
 {
+    /** @var StreamSelectLoop */
     private $loop;
+
+    /** @var Factory */
     private $factory;
+
+    /** @var string */
     private $uri;
 
-    /**
-     * @before
-     */
-    public function setUpFactory()
+    public function setUp(): void
     {
-        $this->uri = getenv('REDIS_URI');
-        if ($this->uri === false) {
+        $this->uri = getenv('REDIS_URI') ?: '';
+        if ($this->uri === '') {
             $this->markTestSkipped('No REDIS_URI environment variable given');
         }
 

--- a/tests/LazyClientTest.php
+++ b/tests/LazyClientTest.php
@@ -5,6 +5,7 @@ namespace Clue\Tests\React\Redis;
 use Clue\React\Redis\Client;
 use Clue\React\Redis\Factory;
 use Clue\React\Redis\LazyClient;
+use PHPUnit\Framework\MockObject\MockObject;
 use React\EventLoop\LoopInterface;
 use React\EventLoop\TimerInterface;
 use React\Promise\Promise;
@@ -12,14 +13,16 @@ use React\Promise\Deferred;
 
 class LazyClientTest extends TestCase
 {
+    /** @var MockObject */
     private $factory;
+
+    /** @var MockObject */
     private $loop;
+
+    /** @var LazyClient */
     private $redis;
 
-    /**
-     * @before
-     */
-    public function setUpClient()
+    public function setUp(): void
     {
         $this->factory = $this->createMock(Factory::class);
         $this->loop = $this->createMock(LoopInterface::class);
@@ -235,7 +238,7 @@ class LazyClientTest extends TestCase
     {
         $client = $this->createMock(Client::class);
         $client->expects($this->once())->method('__call')->willReturn(\React\Promise\resolve());
-        $client->expects($this->once())->method('close')->willReturn(\React\Promise\resolve());
+        $client->expects($this->once())->method('close');
 
         $this->factory->expects($this->once())->method('createClient')->willReturn(\React\Promise\resolve($client));
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,12 +3,13 @@
 namespace Clue\Tests\React\Redis;
 
 use PHPUnit\Framework\MockObject\MockBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use React\Promise\PromiseInterface;
 
 class TestCase extends BaseTestCase
 {
-    protected function expectCallableOnce()
+    protected function expectCallableOnce(): callable
     {
         $mock = $this->createCallableMock();
         $mock->expects($this->once())->method('__invoke');
@@ -16,7 +17,7 @@ class TestCase extends BaseTestCase
         return $mock;
     }
 
-    protected function expectCallableOnceWith($argument)
+    protected function expectCallableOnceWith($argument): callable
     {
         $mock = $this->createCallableMock();
         $mock->expects($this->once())->method('__invoke')->with($argument);
@@ -24,7 +25,7 @@ class TestCase extends BaseTestCase
         return $mock;
     }
 
-    protected function expectCallableNever()
+    protected function expectCallableNever(): callable
     {
         $mock = $this->createCallableMock();
         $mock->expects($this->never())->method('__invoke');
@@ -32,7 +33,7 @@ class TestCase extends BaseTestCase
         return $mock;
     }
 
-    protected function createCallableMock()
+    protected function createCallableMock(): MockObject
     {
         if (method_exists(MockBuilder::class, 'addMethods')) {
             // PHPUnit 9+
@@ -43,11 +44,11 @@ class TestCase extends BaseTestCase
         }
     }
 
-    protected function expectPromiseResolve($promise)
+    protected function expectPromiseResolve(PromiseInterface $promise): PromiseInterface
     {
         $this->assertInstanceOf(PromiseInterface::class, $promise);
 
-        $promise->then(null, function($error) {
+        $promise->then(null, function(\Exception $error) {
             $this->assertNull($error);
             $this->fail('promise rejected');
         });
@@ -56,7 +57,7 @@ class TestCase extends BaseTestCase
         return $promise;
     }
 
-    protected function expectPromiseReject($promise)
+    protected function expectPromiseReject(PromiseInterface $promise): PromiseInterface
     {
         $this->assertInstanceOf(PromiseInterface::class, $promise);
 


### PR DESCRIPTION
This changeset adds type definitions for all APIs and tests. This is a BC break in the sense that this was not enforced previously, but types are not changed otherwise.

Builds on top of #127 and #125