### PR TITLE
Reduce default idle time to 1ms

### DIFF
--- a/examples/incr.php
+++ b/examples/incr.php
@@ -15,5 +15,3 @@ $redis->get('test')->then(function (string $result) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
     exit(1);
 });
-
-$redis->end();

--- a/examples/publish.php
+++ b/examples/publish.php
@@ -16,5 +16,3 @@ $redis->publish($channel, $message)->then(function (int $received) {
     echo 'Unable to publish: ' . $e->getMessage() . PHP_EOL;
     exit(1);
 });
-
-$redis->end();

--- a/src/RedisClient.php
+++ b/src/RedisClient.php
@@ -44,7 +44,7 @@ class RedisClient extends EventEmitter
     private $loop;
 
     /** @var float */
-    private $idlePeriod = 60.0;
+    private $idlePeriod = 0.001;
 
     /** @var ?TimerInterface */
     private $idleTimer = null;

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -53,9 +53,9 @@ class FunctionalTest extends TestCase
     /**
      * @doesNotPerformAssertions
      */
-    public function testPingLazyWillNotBlockLoopWhenIdleTimeIsSmall()
+    public function testPingLazyWillNotBlockLoop()
     {
-        $redis = new RedisClient($this->uri . '?idle=0', null, $this->loop);
+        $redis = new RedisClient($this->uri, null, $this->loop);
 
         $redis->ping();
 

--- a/tests/RedisClientTest.php
+++ b/tests/RedisClientTest.php
@@ -63,7 +63,7 @@ class RedisClientTest extends TestCase
         $deferred = new Deferred();
         $this->factory->expects($this->once())->method('createClient')->willReturn($deferred->promise());
 
-        $this->loop->expects($this->once())->method('addTimer')->with(60.0, $this->anything());
+        $this->loop->expects($this->once())->method('addTimer')->with(0.001, $this->anything());
 
         $promise = $this->redis->ping();
         $deferred->resolve($client);


### PR DESCRIPTION
This simple changeset reduces the default idle time to 1ms (previously 60s). This makes it easier to use the `RedisClient` also in short-lived applications as you no longer have to wait for it to time out for most common use cases.

The idle time can be configured using the `?idle=10.0` parameter as usual for more specific requirements. This can be particularly useful if you have a long-running application with sporadic requests to Redis and a noticeable overhead for (re-)creating the underlying connection over a slow network.

I've also looked into renaming the "idle" time to "keepalive" but feel this would be misworded at this point. The "idle" time only defines the time the client is willing to keep the underlying connection alive without trying to automatically close it. Specifically, the mechanism does not include any messages to actively keep the connection alive using heartbeat messages.

Builds on top of #129 and #87
Refs #118 