### PR TITLE
Forward compatibility with upcoming Promise v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
         "clue/redis-protocol": "0.3.*",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/event-loop": "^1.2",
-        "react/promise": "^2.0 || ^1.1",
-        "react/promise-timer": "^1.8",
-        "react/socket": "^1.9"
+        "react/promise": "^3 || ^2.0 || ^1.1",
+        "react/promise-timer": "^1.9",
+        "react/socket": "^1.12"
     },
     "require-dev": {
-        "clue/block-react": "^1.1",
+        "clue/block-react": "^1.5",
         "phpunit/phpunit": "^9.3 || ^7.5"
     },
     "autoload": {

--- a/tests/RedisClientTest.php
+++ b/tests/RedisClientTest.php
@@ -223,7 +223,7 @@ class RedisClientTest extends TestCase
 
         $this->redis->ping();
         $this->redis->ping();
-        $deferred->resolve();
+        $deferred->resolve(null);
     }
 
     public function testPingAfterPingWillStartAndCancelIdleTimerWhenSecondPingStartsAfterFirstResolves()
@@ -242,14 +242,14 @@ class RedisClientTest extends TestCase
         $this->loop->expects($this->once())->method('cancelTimer')->with($timer);
 
         $this->redis->ping();
-        $deferred->resolve();
+        $deferred->resolve(null);
         $this->redis->ping();
     }
 
     public function testPingFollowedByIdleTimerWillCloseUnderlyingConnectionWithoutCloseEvent()
     {
         $client = $this->createMock(StreamingClient::class);
-        $client->expects($this->once())->method('__call')->willReturn(\React\Promise\resolve());
+        $client->expects($this->once())->method('__call')->willReturn(\React\Promise\resolve(null));
         $client->expects($this->once())->method('close');
 
         $this->factory->expects($this->once())->method('createClient')->willReturn(\React\Promise\resolve($client));
@@ -312,7 +312,7 @@ class RedisClientTest extends TestCase
     public function testCloseAfterPingWillCloseUnderlyingClientConnectionWhenAlreadyResolved()
     {
         $client = $this->createMock(StreamingClient::class);
-        $client->expects($this->once())->method('__call')->willReturn(\React\Promise\resolve());
+        $client->expects($this->once())->method('__call')->willReturn(\React\Promise\resolve(null));
         $client->expects($this->once())->method('close');
 
         $deferred = new Deferred();
@@ -337,7 +337,7 @@ class RedisClientTest extends TestCase
         $this->loop->expects($this->once())->method('cancelTimer')->with($timer);
 
         $this->redis->ping();
-        $deferred->resolve();
+        $deferred->resolve(null);
         $this->redis->close();
     }
 
@@ -414,7 +414,7 @@ class RedisClientTest extends TestCase
         $error = new \RuntimeException();
 
         $client = $this->createMock(StreamingClient::class);
-        $client->expects($this->once())->method('__call')->willReturn(\React\Promise\resolve());
+        $client->expects($this->once())->method('__call')->willReturn(\React\Promise\resolve(null));
 
         $deferred = new Deferred();
         $this->factory->expects($this->once())->method('createClient')->willReturn($deferred->promise());
@@ -429,7 +429,7 @@ class RedisClientTest extends TestCase
     public function testEmitsNoCloseEventWhenUnderlyingClientEmitsClose()
     {
         $client = $this->createMock(StreamingClient::class);
-        $client->expects($this->once())->method('__call')->willReturn(\React\Promise\resolve());
+        $client->expects($this->once())->method('__call')->willReturn(\React\Promise\resolve(null));
 
         $deferred = new Deferred();
         $this->factory->expects($this->once())->method('createClient')->willReturn($deferred->promise());
@@ -463,7 +463,7 @@ class RedisClientTest extends TestCase
         $this->redis->on('close', $this->expectCallableNever());
 
         $this->redis->ping();
-        $deferred->resolve();
+        $deferred->resolve(null);
 
         $this->assertTrue(is_callable($closeHandler));
         $closeHandler();
@@ -473,7 +473,7 @@ class RedisClientTest extends TestCase
     {
         $messageHandler = null;
         $client = $this->createMock(StreamingClient::class);
-        $client->expects($this->once())->method('__call')->willReturn(\React\Promise\resolve());
+        $client->expects($this->once())->method('__call')->willReturn(\React\Promise\resolve(null));
         $client->expects($this->any())->method('on')->willReturnCallback(function ($event, $callback) use (&$messageHandler) {
             if ($event === 'message') {
                 $messageHandler = $callback;
@@ -495,7 +495,7 @@ class RedisClientTest extends TestCase
     {
         $allHandler = null;
         $client = $this->createMock(StreamingClient::class);
-        $client->expects($this->exactly(6))->method('__call')->willReturn(\React\Promise\resolve());
+        $client->expects($this->exactly(6))->method('__call')->willReturn(\React\Promise\resolve(null));
         $client->expects($this->any())->method('on')->willReturnCallback(function ($event, $callback) use (&$allHandler) {
             if (!isset($allHandler[$event])) {
                 $allHandler[$event] = $callback;


### PR DESCRIPTION
Builds on top of https://github.com/reactphp/socket/pull/214, https://github.com/reactphp/promise/pull/213, https://github.com/reactphp/promise-timer/pull/54 and https://github.com/clue/reactphp-block/pull/61