### PR TITLE
Update test suite to use new reactphp/async package instead of clue/reactphp-block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "react/event-loop": "^1.2",
         "react/promise": "^3 || ^2.0 || ^1.1",
         "react/promise-timer": "^1.10",
-        "react/socket": "^1.12"
+        "react/socket": "dev-cancel-happy as 1.15.0"
     },
     "require-dev": {
         "clue/block-react": "^1.5",
@@ -29,5 +29,11 @@
     },
     "autoload-dev": {
         "psr-4": { "Clue\\Tests\\React\\Redis\\": "tests/" }
+    },
+    "repositories": {
+        "clue": {
+            "type": "vcs",
+            "url": "https://github.com/clue-labs/socket"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "react/event-loop": "^1.2",
         "react/promise": "^3 || ^2.0 || ^1.1",
         "react/promise-timer": "^1.10",
-        "react/socket": "dev-cancel-happy as 1.15.0"
+        "react/socket": "^1.15"
     },
     "require-dev": {
         "phpstan/phpstan": "1.10.15 || 1.4.10",
@@ -29,11 +29,5 @@
     },
     "autoload-dev": {
         "psr-4": { "Clue\\Tests\\React\\Redis\\": "tests/" }
-    },
-    "repositories": {
-        "clue": {
-            "type": "vcs",
-            "url": "https://github.com/clue-labs/socket"
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         "react/socket": "dev-cancel-happy as 1.15.0"
     },
     "require-dev": {
-        "clue/block-react": "^1.5",
         "phpstan/phpstan": "1.10.15 || 1.4.10",
-        "phpunit/phpunit": "^9.6 || ^7.5"
+        "phpunit/phpunit": "^9.6 || ^7.5",
+        "react/async": "^4.2 || ^3.2"
     },
     "autoload": {
         "psr-4": { "Clue\\React\\Redis\\": "src/" }


### PR DESCRIPTION
See https://github.com/reactphp/async
Refs https://github.com/clue/reactphp-block/issues/68 and https://github.com/clue/reactphp-block/pull/67
Builds on top of https://github.com/reactphp/async/pull/40, https://github.com/reactphp/async/pull/82, https://github.com/reactphp/socket/pull/311, #145, #140 and others
Supersedes / closes #135, thank you @dinooo13!