### PR TITLE
[2.x] Forward compatibility with Promise v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
         "clue/redis-protocol": "0.3.*",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/event-loop": "^1.2",
-        "react/promise": "^2.0 || ^1.1",
-        "react/promise-timer": "^1.8",
-        "react/socket": "^1.9"
+        "react/promise": "^3 || ^2.0 || ^1.1",
+        "react/promise-timer": "^1.9",
+        "react/socket": "^1.12"
     },
     "require-dev": {
-        "clue/block-react": "^1.1",
+        "clue/block-react": "^1.5",
         "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
     },
     "autoload": {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -84,6 +84,8 @@ class Factory
             // either close successful connection or cancel pending connection attempt
             $connecting->then(function (ConnectionInterface $connection) {
                 $connection->close();
+            }, function () {
+                // ignore to avoid reporting unhandled rejection
             });
             $connecting->cancel();
         });

--- a/src/LazyClient.php
+++ b/src/LazyClient.php
@@ -168,6 +168,8 @@ class LazyClient extends EventEmitter implements Client
         if ($this->promise !== null) {
             $this->promise->then(function (Client $redis) {
                 $redis->close();
+            }, function () {
+                // ignore to avoid reporting unhandled rejection
             });
             if ($this->promise !== null) {
                 $this->promise->cancel();

--- a/tests/FactoryLazyClientTest.php
+++ b/tests/FactoryLazyClientTest.php
@@ -34,13 +34,13 @@ class FactoryLazyClientTest extends TestCase
 
     public function testWillConnectWithDefaultPort()
     {
-        $this->connector->expects($this->never())->method('connect')->with('redis.example.com:6379')->willReturn(Promise\reject(new \RuntimeException()));
+        $this->connector->expects($this->never())->method('connect');
         $this->factory->createLazyClient('redis.example.com');
     }
 
     public function testWillConnectToLocalhost()
     {
-        $this->connector->expects($this->never())->method('connect')->with('localhost:1337')->willReturn(Promise\reject(new \RuntimeException()));
+        $this->connector->expects($this->never())->method('connect');
         $this->factory->createLazyClient('localhost:1337');
     }
 
@@ -147,7 +147,7 @@ class FactoryLazyClientTest extends TestCase
 
     public function testWillRejectIfConnectorRejects()
     {
-        $this->connector->expects($this->never())->method('connect')->with('127.0.0.1:2')->willReturn(Promise\reject(new \RuntimeException()));
+        $this->connector->expects($this->never())->method('connect');
         $redis = $this->factory->createLazyClient('redis://127.0.0.1:2');
 
         $this->assertInstanceOf('Clue\React\Redis\Client', $redis);

--- a/tests/FactoryStreamingClientTest.php
+++ b/tests/FactoryStreamingClientTest.php
@@ -44,13 +44,17 @@ class FactoryStreamingClientTest extends TestCase
     public function testWillConnectWithDefaultPort()
     {
         $this->connector->expects($this->once())->method('connect')->with('redis.example.com:6379')->willReturn(Promise\reject(new \RuntimeException()));
-        $this->factory->createClient('redis.example.com');
+        $promise = $this->factory->createClient('redis.example.com');
+
+        $promise->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
     }
 
     public function testWillConnectToLocalhost()
     {
         $this->connector->expects($this->once())->method('connect')->with('localhost:1337')->willReturn(Promise\reject(new \RuntimeException()));
-        $this->factory->createClient('localhost:1337');
+        $promise = $this->factory->createClient('localhost:1337');
+
+        $promise->then(null, $this->expectCallableOnce()); // avoid reporting unhandled rejection
     }
 
     public function testWillResolveIfConnectorResolves()


### PR DESCRIPTION
This changeset backports the changes from #134 and #144 from `3.x` to `2.x`.

Builds on top of #134, #144 and #151 which in turn build on top of https://github.com/reactphp/socket/pull/214, https://github.com/reactphp/promise/pull/213, https://github.com/reactphp/promise-timer/pull/54, https://github.com/clue/reactphp-block/pull/61, https://github.com/reactphp/promise/pull/248 and others
Resolves / Closes #148
Refs #150