### PR TITLE
Include timeout logic to avoid dependency on reactphp/promise-timer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/event-loop": "^1.2",
         "react/promise": "^3",
-        "react/promise-timer": "^1.10",
         "react/socket": "^1.15"
     },
     "require-dev": {


### PR DESCRIPTION
This changeset adds timeout logic to avoid the otherwise unneeded dependency on [reactphp/promise-timer](https://github.com/reactphp/promise-timer). There are plans to deprecate the reactphp/promise-stream package as discussed in https://github.com/orgs/reactphp/discussions/475 and in either case I'd like to remove additional dependencies where possible.

This changeset does not otherwise affect our public API, so this should be safe to apply. The test suite confirms this has 100% code coverage and does not otherwise affect our APIs.

Builds on top of https://github.com/reactphp/socket/pull/305, #150, #149 and others