### PR TITLE
Remove optional `$loop` constructor argument, always use default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,12 +413,6 @@ $connector = new React\Socket\Connector([
 $redis = new Clue\React\Redis\RedisClient('localhost', $connector);
 ```
 
-This class takes an optional `LoopInterface|null $loop` parameter that can be used to
-pass the event loop instance to use for this object. You can use a `null` value
-here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
-This value SHOULD NOT be given unless you're sure you want to explicitly use a
-given event loop instance.
-
 #### __call()
 
 The `__call(string $name, string[] $args): PromiseInterface<mixed>` method can be used to

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -10,7 +10,6 @@ use function React\Async\await;
 
 class FunctionalTest extends TestCase
 {
-
     /** @var string */
     private $uri;
 


### PR DESCRIPTION
This changeset removes the optional `$loop` constructor arguments and ensures we always use the default loop. Empirical evidence suggests this should not affect most consumers, as using the default loop is recommended since a couple of years at least (#114). Among others, this is one of the prerequisites for adding `await()`-based APIs in a follow-up PR.

Builds on top of #149, #129, #114 and others
Refs #118