### PR TITLE
Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
     ],
     "require": {
         "php": ">=7.1",
-        "clue/redis-protocol": "0.3.*",
+        "clue/redis-protocol": "^0.3.2",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
         "react/event-loop": "^1.2",
-        "react/promise": "^3",
-        "react/socket": "^1.15"
+        "react/promise": "^3.2",
+        "react/socket": "^1.16"
     },
     "require-dev": {
         "phpstan/phpstan": "1.10.15 || 1.4.10",
         "phpunit/phpunit": "^9.6 || ^7.5",
-        "react/async": "^4.2 || ^3.2"
+        "react/async": "^4.3 || ^3.2"
     },
     "autoload": {
         "psr-4": { 

--- a/src/Io/Factory.php
+++ b/src/Io/Factory.php
@@ -27,7 +27,7 @@ class Factory
      * @param ?ConnectorInterface $connector
      * @param ?ProtocolFactory $protocol
      */
-    public function __construct(ConnectorInterface $connector = null, ProtocolFactory $protocol = null)
+    public function __construct(?ConnectorInterface $connector = null, ?ProtocolFactory $protocol = null)
     {
         $this->connector = $connector ?: new Connector();
         $this->protocol = $protocol ?: new ProtocolFactory();

--- a/src/RedisClient.php
+++ b/src/RedisClient.php
@@ -54,7 +54,7 @@ class RedisClient extends EventEmitter
     /** @var array<string,bool> */
     private $psubscribed = [];
 
-    public function __construct(string $url, ConnectorInterface $connector = null)
+    public function __construct(string $url, ?ConnectorInterface $connector = null)
     {
         $args = [];
         \parse_str((string) \parse_url($url, \PHP_URL_QUERY), $args);


### PR DESCRIPTION
This changeset improves PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260.

Once merged, we can apply similar changes to all downstream components. On top of this, we may want to backport similar changes to the v2 branch.

Builds on top of #147, #156, #150, #127, https://github.com/reactphp/promise/pull/260, https://github.com/reactphp/socket/pull/318, https://github.com/reactphp/async/pull/87 and https://github.com/clue/redis-protocol/pull/19