### PR TITLE
[2.x] Fix passing internal protocol factory to `Factory` class

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -25,7 +25,7 @@ class Factory
     /**
      * @param ?LoopInterface $loop
      * @param ?ConnectorInterface $connector
-     * @param ?ProtocolFactory $protocol
+     * @param ?ProtocolFactory $protocol (internal, should not usually be passed)
      */
     public function __construct($loop = null, $connector = null, $protocol = null)
     {
@@ -35,7 +35,7 @@ class Factory
         if ($connector !== null && !$connector instanceof ConnectorInterface) { // manual type check to support legacy PHP < 7.1
             throw new \InvalidArgumentException('Argument #2 ($connector) expected null|React\Socket\ConnectorInterface');
         }
-        if ($protocol !== null && !$protocol instanceof LoopInterface) { // manual type check to support legacy PHP < 7.1
+        if ($protocol !== null && !$protocol instanceof ProtocolFactory) { // manual type check to support legacy PHP < 7.1
             throw new \InvalidArgumentException('Argument #3 ($protocol) expected null|Clue\Redis\Protocol\Factory');
         }
 

--- a/tests/FactoryLazyClientTest.php
+++ b/tests/FactoryLazyClientTest.php
@@ -32,6 +32,18 @@ class FactoryLazyClientTest extends TestCase
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
     }
 
+    public function testConstructWithProtocolFactoryAssignsGivenProtocolFactory()
+    {
+        $protocol = $this->getMockBuilder('Clue\Redis\Protocol\Factory')->getMock();
+
+        $factory = new Factory(null, null, $protocol);
+
+        $ref = new \ReflectionProperty($factory, 'protocol');
+        $ref->setAccessible(true);
+
+        $this->assertSame($protocol, $ref->getValue($factory));
+    }
+
     public function testContructorThrowsExceptionForInvalidLoop()
     {
         $this->setExpectedException('InvalidArgumentException', 'Argument #1 ($loop) expected null|React\EventLoop\LoopInterface');


### PR DESCRIPTION
This fixes a subtle bug introduced recently in #165 that would use a wrong type check for the internal protocol factory. This only affects the `2.x` development version with no tag being affected, nor does this affect the `3.x` development version which users proper type checks as per #157 and PHPStan as per #140.

Builds on top of #165
Refs #157 