### PR TITLE
Automatically convert numeric arguments passed to any Redis commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Listing all available commands is out of scope here, please refer to the
 
 Any arguments passed to the method call will be forwarded as command arguments.
 For example, the `$redis->set('name', 'Alice')` call will perform the equivalent of a
-`SET name Alice` command. It's safe to pass integer arguments where applicable (for
+`SET name Alice` command. It's safe to pass numeric arguments where applicable (for
 example `$redis->expire($key, 60)`), but internally Redis requires all arguments to
 always be coerced to string values.
 
@@ -417,7 +417,7 @@ $redis = new Clue\React\Redis\RedisClient('localhost', $connector);
 
 #### __call()
 
-The `__call(string $name, string[] $args): PromiseInterface<mixed>` method can be used to
+The `__call(string $name, list<string|int|float> $args): PromiseInterface<mixed>` method can be used to
 invoke the given command.
 
 This is a magic method that will be invoked when calling any Redis command on this instance.
@@ -441,7 +441,7 @@ Listing all available commands is out of scope here, please refer to the
 
 Any arguments passed to the method call will be forwarded as command arguments.
 For example, the `$redis->set('name', 'Alice')` call will perform the equivalent of a
-`SET name Alice` command. It's safe to pass integer arguments where applicable (for
+`SET name Alice` command. It's safe to pass numeric arguments where applicable (for
 example `$redis->expire($key, 60)`), but internally Redis requires all arguments to
 always be coerced to string values.
 
@@ -451,8 +451,11 @@ that eventually *fulfills* with its *results* on success or *rejects* with an
 
 #### callAsync()
 
-The `callAsync(string $command, string ...$args): PromiseInterface<mixed>` method can be used to
+The `callAsync(string $command, string|int|float ...$args): PromiseInterface<mixed>` method can be used to
 invoke a Redis command.
+
+For example, the [`GET` command](https://redis.io/commands/get) can be invoked
+like this:
 
 ```php
 $redis->callAsync('GET', 'name')->then(function (?string $name): void {
@@ -470,12 +473,10 @@ may understand this magic method. Listing all available commands is out
 of scope here, please refer to the
 [Redis command reference](https://redis.io/commands).
 
-The optional `string ...$args` parameter can be used to pass any
-additional arguments to the Redis command. Some commands may require or
-support additional arguments that this method will simply forward as is.
-Internally, Redis requires all arguments to be coerced to `string` values,
-but you may also rely on PHP's type-juggling semantics and pass `int` or
-`float` values:
+The optional `string|int|float ...$args` parameter can be used to pass
+any additional arguments that some Redis commands may require or support.
+Values get passed directly to Redis, with any numeric values converted
+automatically since Redis only works with `string` arguments internally:
 
 ```php
 $redis->callAsync('SET', 'name', 'Alice', 'EX', 600);

--- a/src/RedisClient.php
+++ b/src/RedisClient.php
@@ -165,8 +165,8 @@ class RedisClient extends EventEmitter
      * This is a magic method that will be invoked when calling any redis
      * command on this instance. See also `RedisClient::callAsync()`.
      *
-     * @param string   $name
-     * @param string[] $args
+     * @param string $name
+     * @param list<string|int|float> $args
      * @return PromiseInterface<mixed>
      * @see self::callAsync()
      */
@@ -197,12 +197,10 @@ class RedisClient extends EventEmitter
      * of scope here, please refer to the
      * [Redis command reference](https://redis.io/commands).
      *
-     * The optional `string ...$args` parameter can be used to pass any
-     * additional arguments to the Redis command. Some commands may require or
-     * support additional arguments that this method will simply forward as is.
-     * Internally, Redis requires all arguments to be coerced to `string` values,
-     * but you may also rely on PHP's type-juggling semantics and pass `int` or
-     * `float` values:
+     * The optional `string|int|float ...$args` parameter can be used to pass
+     * any additional arguments that some Redis commands may require or support.
+     * Values get passed directly to Redis, with any numeric values converted
+     * automatically since Redis only works with `string` arguments internally:
      *
      * ```php
      * $redis->callAsync('SET', 'name', 'Alice', 'EX', 600);
@@ -214,12 +212,23 @@ class RedisClient extends EventEmitter
      * details.
      *
      * @param string $command
-     * @param string ...$args
+     * @param string|int|float ...$args
      * @return PromiseInterface<mixed>
-     * @throws void
+     * @throws \TypeError if given $args are invalid
      */
-    public function callAsync(string $command, string ...$args): PromiseInterface
+    public function callAsync(string $command, ...$args): PromiseInterface
     {
+        $args = \array_map(function ($value): string {
+            /** @var mixed $value */
+            if (\is_string($value)) {
+                return $value;
+            } elseif (\is_int($value) || \is_float($value)) {
+                return \var_export($value, true);
+            } else {
+                throw new \TypeError('Argument must be of type string|int|float, ' . (\is_object($value) ? \get_class($value) : \gettype($value)) . ' given');
+            }
+        }, $args);
+
         if ($this->closed) {
             return reject(new \RuntimeException(
                 'Connection closed (ENOTCONN)',

--- a/tests/RedisClientTest.php
+++ b/tests/RedisClientTest.php
@@ -407,6 +407,64 @@ class RedisClientTest extends TestCase
         $timeout();
     }
 
+    public function testBlpopWillForwardArgumentsAsStringToUnderlyingClient(): void
+    {
+        $client = $this->createMock(StreamingClient::class);
+        $client->expects($this->once())->method('callAsync')->with('BLPOP', 'foo', 'bar', '10.0')->willReturn(new Promise(function () { }));
+
+        $this->factory->expects($this->once())->method('createClient')->willReturn(\React\Promise\resolve($client));
+
+        $loop = $this->createMock(LoopInterface::class);
+        $loop->expects($this->never())->method('addTimer');
+        assert($loop instanceof LoopInterface);
+        Loop::set($loop);
+
+        $this->redis->callAsync('BLPOP', 'foo', 'bar', 10.0);
+    }
+
+    public function testCallAsyncWillForwardArgumentsAsStringToUnderlyingClient(): void
+    {
+        $client = $this->createMock(StreamingClient::class);
+        $client->expects($this->once())->method('callAsync')->with('ZCOUNT', 'foo', '-INF', 'INF')->willReturn(new Promise(function () { }));
+
+        $this->factory->expects($this->once())->method('createClient')->willReturn(\React\Promise\resolve($client));
+
+        $loop = $this->createMock(LoopInterface::class);
+        $loop->expects($this->never())->method('addTimer');
+        assert($loop instanceof LoopInterface);
+        Loop::set($loop);
+
+        $this->redis->callAsync('ZCOUNT', 'foo', -INF, INF);
+    }
+
+    public function testSetWithInvalidBoolArgumentThrows(): void
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Argument must be of type string|int|float, boolean given');
+        $this->redis->set('foo', true);
+    }
+
+    public function testSetWithInvalidObjectArgumentThrows(): void
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Argument must be of type string|int|float, stdClass given');
+        $this->redis->set('foo', (object) []);
+    }
+
+    public function testCallAsyncWithInvalidBoolArgumentThrows(): void
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Argument must be of type string|int|float, boolean given');
+        $this->redis->callAsync('SET', 'foo', true); // @phpstan-ignore-line
+    }
+
+    public function testCallAsyncWithInvalidObjectArgumentThrows(): void
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Argument must be of type string|int|float, stdClass given');
+        $this->redis->callAsync('SET', 'foo', (object) []); // @phpstan-ignore-line
+    }
+
     public function testCloseWillEmitCloseEventWithoutCreatingUnderlyingClient(): void
     {
         $this->factory->expects($this->never())->method('createClient');


### PR DESCRIPTION
This changeset makes sure we automatically convert numeric arguments passed to any Redis commands. This is particularly useful when using the new `callAsync()` method with static analysis tools:

```php
// old (still supported)
$redis->callAsync('SET', 'name', 'Alice', 'EX', '60');

// new
$redis->callAsync('GET', 'name', 'Alice', 'EX', 60);
```

Builds on top of #166, #140, #128, #127 and others 