### PR TITLE
Update tests to work around segfault on PHP 8.4.4 with Xdebug 3.5.0-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: xdebug-stable # temporarily force stable Xdebug due to segfault on PHP 8.4.4 with 3.5.0-dev
           coverage: xdebug
           ini-file: development
       - run: composer install


### PR DESCRIPTION
This changeset updates the tests to work around a segfault on PHP 8.4.4 with Xdebug 3.5.0-dev.

We've started seeing consistent segfaults on PHP 8.4 only while working on #172. The tests worked just fine last Saturday (https://github.com/clue/reactphp-redis/actions/runs/13345833218) and started failing the next day (https://github.com/clue/reactphp-redis/actions/runs/13358390672) after applying some non-substantial style changes. Reverting these changes didn't change anything, so we went on to check for platform changes.

The build output above suggests the Saturday output used PHP 8.4.3, while Sunday used PHP 8.4.4. The `shivammathur/setup-php@v2` action suggests both builds use the same `Xdebug 3.5.0-dev enabled as coverage driver`, while all older PHP versions use `Xdebug-3.4.1`. After toying around with some different approaches, it looks like always pinning this to the stable Xdebug version fixes this consistently, so I assume there might be some incompatibility between the Xdebug dev version and the most current PHP version only.

Using the stable Xdebug version seems reasonable and doesn't seem to cause any noticeable side-effects. I noticed only the PHP 8.4 install now takes ~15 seconds longer because the Xdebug version doesn't appear to be cached by default.

I wonder how widespread this problem would be exactly, as I don't see anything special that this project would execute (except perhaps for Fibers as of #149?). In either case, we should probably report this upstream to Xdebug and/or shivammathur/setup-php.

Builds on top of #164
Refs #172