### PR TITLE
Revert "Update tests to work around segfault on PHP 8.4.4 with Xdebug 3.5.0-dev"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: xdebug-stable # temporarily force stable Xdebug due to segfault on PHP 8.4.4 with 3.5.0-dev
           coverage: xdebug
           ini-file: development
       - run: composer install


### PR DESCRIPTION
This changeset reverts #173 as it no longer appears to be necessary to apply this temporary workaround.

The `shivammathur/setup-php@v2` action suggests all builds now use the same `Xdebug 3.4.1 enabled as coverage driver` across all supported PHP versions, while previous builds would use `Xdebug 3.5.0-dev` on PHP 8.4 only that would cause a segfault. I could not locate a changelog that describes this change unfortunately, but at least it should now work out-of-the-box again.

In either case, we may still want to report this upstream to Xdebug and/or shivammathur/setup-php.

Refs #173 and https://github.com/clue/framework-x/pull/276