### PR TITLE
Update test suite to use PCOV to avoid segfault with Xdebug 3.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: xdebug
+          coverage: ${{ matrix.php < 8.0 && 'xdebug' || 'pcov' }}
           ini-file: development
       - run: composer install
       - run: docker run --net=host -d redis


### PR DESCRIPTION
This changeset updates the test suite to use PCOV instead of Xdebug on PHP 8+ to avoid a segfault with Xdebug 3.4.2 on PHP 8.1+ (https://bugs.xdebug.org/view.php?id=2332).

Builds on top of https://github.com/clue/framework-x/pull/278, #174, #173