### PR TITLE
Run tests on PHP 8.5 and update test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.5
           - 8.4
           - 8.3
           - 8.2
@@ -21,7 +22,7 @@ jobs:
           - 7.2
           - 7.1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -46,6 +47,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.5
           - 8.4
           - 8.3
           - 8.2
@@ -56,7 +58,7 @@ jobs:
           - 7.2
           - 7.1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
         "php": ">=7.1",
         "clue/redis-protocol": "^0.3.2",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-        "react/event-loop": "^1.2",
-        "react/promise": "^3.2",
-        "react/socket": "^1.16"
+        "react/event-loop": "^1.6",
+        "react/promise": "^3.3",
+        "react/socket": "^1.17"
     },
     "require-dev": {
-        "phpstan/phpstan": "1.12.13 || 1.4.10",
+        "phpstan/phpstan": "1.12.32 || 1.4.10",
         "phpunit/phpunit": "^9.6 || ^7.5",
         "react/async": "^4.3 || ^3.2"
     },

--- a/tests/RedisClientTest.php
+++ b/tests/RedisClientTest.php
@@ -40,7 +40,9 @@ class RedisClientTest extends TestCase
         $this->redis = new RedisClient('localhost');
 
         $ref = new \ReflectionProperty($this->redis, 'factory');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($this->redis, $this->factory);
     }
 
@@ -124,7 +126,9 @@ class RedisClientTest extends TestCase
     {
         $this->redis = new RedisClient('user:pass@localhost');
         $ref = new \ReflectionProperty($this->redis, 'factory');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($this->redis, $this->factory);
 
         $promise = new Promise(function () { });
@@ -144,7 +148,9 @@ class RedisClientTest extends TestCase
     {
         $this->redis = new RedisClient('redis+unix:///tmp/redis.sock');
         $ref = new \ReflectionProperty($this->redis, 'factory');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($this->redis, $this->factory);
 
         $promise = new Promise(function () { });
@@ -193,7 +199,9 @@ class RedisClientTest extends TestCase
         $this->redis = new RedisClient('localhost?idle=10');
 
         $ref = new \ReflectionProperty($this->redis, 'factory');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($this->redis, $this->factory);
 
         $client = $this->createMock(StreamingClient::class);
@@ -218,7 +226,9 @@ class RedisClientTest extends TestCase
         $this->redis = new RedisClient('localhost?idle=-1');
 
         $ref = new \ReflectionProperty($this->redis, 'factory');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $ref->setValue($this->redis, $this->factory);
 
         $client = $this->createMock(StreamingClient::class);


### PR DESCRIPTION
Builds on top of #164, https://github.com/reactphp/socket/pull/325, https://github.com/reactphp/promise/pull/264, https://github.com/reactphp/event-loop/pull/282, and https://github.com/clue/framework-x/pull/297