### PR TITLE
Update test environment to fix tests on legacy PHP 7.2 with PHPUnit 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,7 @@ jobs:
           ini-file: development
       - run: composer install
       - run: docker run --net=host -d redis
-      - run: REDIS_URI=localhost:6379 vendor/bin/phpunit --coverage-text --coverage-clover=clover.xml
-        if: ${{ matrix.php >= 7.3 }}
-      - run: REDIS_URI=localhost:6379 vendor/bin/phpunit --coverage-text --coverage-clover=clover.xml -c phpunit.xml.legacy
-        if: ${{ matrix.php < 7.3 }}
+      - run: REDIS_URI=localhost:6379 vendor/bin/phpunit --coverage-text --coverage-clover=clover.xml ${{ matrix.php < 7.3 && '-c phpunit.xml.legacy' || '' }}
       - name: Check 100% code coverage
         shell: php {0}
         run: |

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "1.12.32 || 1.4.10",
-        "phpunit/phpunit": "^9.6 || ^7.5",
+        "phpunit/phpunit": "^9.6 || ^8.5 || ^7.5",
         "react/async": "^4.3 || ^3.2"
     },
     "autoload": {


### PR DESCRIPTION
This changeset updates the test environment to fix tests on legacy PHP 7.2 with PHPUnit 8.5. This is needed to run the tests on legacy platforms due to recent upstream changes:

* A recent security advisory ([GHSA-vvj3-c3rp-c85p](https://github.com/advisories/GHSA-vvj3-c3rp-c85p)) affects most PHPUnit versions. It was patched in actively supported releases, but not in legacy PHPUnit versions, which we rely on for tests on legacy PHP < 7.3.
* Composer 2.9 now blocks installing packages with known advisories by default (https://github.com/composer/composer/pull/11956). Legacy PHP < 7.2 uses older Composer versions.
* While this project should not be affected by the advisory, both things combined mean that Composer would fail on legacy PHP 7.2 only ("Your requirements could not be resolved to an installable set of packages.")
* The suggested changes allow using PHPUnit 8.5 on PHP 7.2 until we remove legacy platforms in the future.

Builds on top of #104 and #127 and others